### PR TITLE
Feature/file interface for recording test evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,110 @@
 # pytest-junit-xray-xml
 This plugin for [pytest](https://pytest.org) exports test results in an extended JUnit format for consumption by the [Xray plugin](https://www.getxray.app/)
  for [Jira](https://www.atlassian.com/software/jira).
+
+This plugin aims to also be a drop-in replacement for `pytest`'s built-in JUnit support, so all non-Xray-related functionality will (hopefully soon) be supported.
+## Rationale
+The JUnit support in `pytest` does not allow for the following features:
+- it is not possible to generate `<item>` elements as subnodes of a `<property>` tag (needed for storing test evidence)
+- it is not possible to store `text` in a `property` tag
+
+## Installation
+This package is available on [pypi.org](https://pypi.org/project/pytest-junit-xray-xml/)
+```shell
+python -m pip install pytest-junit-xray-xml
+```
+
+## Usage
+> [!NOTE]
+> You need to explicitly import all fixtures that you want to use, e.g. `from pytest_junit_xray_xml import record_test_key`
+
+To export the results as Xray-compatible JUnit, please start pytest with the parameter `--junit-xray-xml <filename.xml>`, e.g.
+```shell
+python -m pytest tests/examples.py --junit-xray-xml xray.xml
+```
+(All examples are available in [tests/examples.py](tests/examples.py) and can be run via the command above)
+
+The following fixtures are supported.
+
+### record_test_key
+stores the test key in a property named `test_key`. Xray will attach the test results to the test case identified by this key.
+
+> [!ALERT]
+> Only a single test key is supported at the moment
+
+#### example
+```python
+def test_record_test_key(record_test_key):
+    record_test_key("JIRA-1234")
+    assert True
+```
+#### output
+```xml
+<property name="test_key" value="JIRA-1234" />
+```
+
+### record_test_id
+stores the test ID in a property named `test_id`. Xray will attach the test results to the test case identified by this key.
+
+> [!ALERT]
+> Only a single test key is supported at the moment
+
+#### example
+```python
+def test_record_test_key(record_test_key):
+    record_test_key("JIRA-1234")
+    assert True
+```
+#### output
+```xml
+<property name="test_key" value="JIRA-1234" />
+```
+
+### record_test_description
+stores the (potentially multi-line) test description as the `text` of a property named `test_description`. This cannot be accomplished with base `pytest` fixtures.
+#### example
+```python
+def test_record_multiple_descriptions(record_test_description):
+    record_test_description("This is my test description line 1")
+    record_test_description("and line 2.")
+    assert True
+```
+#### output
+```xml
+<property name="test_description">This is my test description line 1
+and line 2.</property>
+```
+
+### record_test_evidence
+stores the test evidence with base64 encoding inside the XML. Xray will attach this file to the corresponding Jira ticket.
+
+Multiple files with evidence can be stored for a single test case (not shown in the example below).
+#### example
+```python
+def test_store_test_evidence(record_test_evidence):
+    with record_test_evidence("file1.txt", "w", encoding="UTF-8") as f:
+        f.write("My file content is text")
+    assert True
+```
+#### output
+```xml
+<property name="testrun_evidence">
+                <item name="file1.txt">TXkgZmlsZSBjb250ZW50IGlzIHRleHQ=</item>
+            </property>
+
+```
+#### example
+```python
+def test_store_test_evidence_xml(record_test_evidence):
+    xml_content = ElementTree(Element("my_root", my_attribute="1"))
+    with record_test_evidence("file1.xml", "wb") as f:
+        xml_content.write(f)
+    assert True
+```
+#### output
+```xml
+<property name="testrun_evidence">
+    <item name="file1.xml">PG15X3Jvb3QgbXlfYXR0cmlidXRlPSIxIiAvPg==</item>
+</property>
+```
+

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,15 +1,15 @@
 from .fixtures import (
-    record_test_evidence,
     record_test_summary,
     record_test_id,
     record_test_description,
-    record_test_key
+    record_test_key,
+    record_test_evidence
 )
 
 __all__ = [
-    "record_test_evidence",
     "record_test_summary",
     "record_test_id",
     "record_test_description",
-    "record_test_key"
+    "record_test_key",
+    "record_test_evidence"
 ]

--- a/src/fixtures.py
+++ b/src/fixtures.py
@@ -22,14 +22,6 @@ def _record_single_item(user_properties, key: str, value: str):
         )
 
 
-def _get_test_evidence_property_item(name: str, content: str) -> dict:
-    result = {
-        "filename": name,
-        "content": base64.b64encode(content).decode("ascii")
-    }
-    return result
-
-
 @pytest.fixture
 def record_test_evidence(request: FixtureRequest) -> typing.Callable[[dict],
                                                                      None]:

--- a/src/fixtures.py
+++ b/src/fixtures.py
@@ -1,4 +1,5 @@
 import base64
+import io
 import typing
 
 import pytest
@@ -21,7 +22,7 @@ def _record_single_item(user_properties, key: str, value: str):
         )
 
 
-def __get_test_evidence_property_item(name: str, content: str) -> dict:
+def _get_test_evidence_property_item(name: str, content: str) -> dict:
     result = {
         "filename": name,
         "content": base64.b64encode(content).decode("ascii")
@@ -32,18 +33,44 @@ def __get_test_evidence_property_item(name: str, content: str) -> dict:
 @pytest.fixture
 def record_test_evidence(request: FixtureRequest) -> typing.Callable[[dict],
                                                                      None]:
-    """records test evidence for consumption by the Jira Xray plugin
+    class InMemoryFile(io.BytesIO):
+        def __init__(self, filename: str, mode: str = "wb",
+                     encoding: str = "UTF-8", *args, **kwargs):
+            self.__filename = filename
+            self.__mode = mode
+            self.__encoding = encoding
+            super().__init__()
 
-    The evidence is attached to the test run object in Jira/Xray as files with"
-    names by their keys
-    """
-    def _record_test_evidence(evidences: dict) -> None:
-        for name_, evidence_ in evidences.items():
-            item_ = __get_test_evidence_property_item(name_, evidence_)
-            request.node.user_properties.append(
-                ("test_evidence", item_)
+        def __exit__(self, *args, **kwargs):
+            item = self._get_test_evidence_encoded(
+                self.__filename, self.getvalue()
             )
-    return _record_test_evidence
+            request.node.user_properties.append(
+                ("test_evidence", item)
+            )
+            super().__exit__()
+
+        def _get_test_evidence_encoded(self, name: str, content: str) -> dict:
+            result = {
+                "filename": name,
+                "content": base64.b64encode(content).decode("ascii")
+            }
+            return result
+
+        def write(self, b, *args, **kwargs):
+            if "b" in self.__mode:
+                super().write(b)
+            elif self.__encoding is None:
+                raise ValueError(
+                    f"Calling InMemoryFile(filename='{self.__filename}', "
+                    f"mode='{self.__mode}', encoding='{self.__encoding}') "
+                    "is not supported: if mode is not binary, you must "
+                    "supply an encoding"
+                )
+            else:
+                super().write(b.encode(self.__encoding), *args, **kwargs)
+
+    return InMemoryFile
 
 
 @pytest.fixture

--- a/tests/examples.py
+++ b/tests/examples.py
@@ -1,0 +1,41 @@
+from xml.etree.ElementTree import ElementTree, Element, canonicalize
+from pytest_junit_xray_xml import (
+    record_test_evidence,
+    record_test_description,
+    record_test_summary,
+    record_test_key
+)
+
+
+def test_record_single_description(record_test_description):
+    record_test_description("This is my test description")
+    assert True
+
+
+def test_record_multiple_descriptions(record_test_description):
+    record_test_description("This is my test description line 1")
+    record_test_description("and line 2.")
+    assert True
+
+
+def test_record_test_key(record_test_key):
+    record_test_key("JIRA-1234")
+    assert True
+
+
+def test_record_summary(record_test_summary):
+    record_test_summary("This is my test summary")
+    assert True
+
+
+def test_store_test_evidence(record_test_evidence):
+    with record_test_evidence("file1.txt", "w", encoding="UTF-8") as f:
+        f.write("My file content is text")
+    assert True
+
+
+def test_store_test_evidence_xml(record_test_evidence):
+    xml_content = ElementTree(Element("my_root", my_attribute="1"))
+    with record_test_evidence("file1.xml", "wb") as f:
+        xml_content.write(f)
+    assert True

--- a/tests/test_junit_xray_xml.py
+++ b/tests/test_junit_xray_xml.py
@@ -1,5 +1,6 @@
+import base64
 import logging
-from xml.etree import ElementTree
+import xml.etree.ElementTree as ET
 
 from _pytest.pytester import Pytester
 
@@ -32,30 +33,8 @@ def run_and_parse(pytester: Pytester, family: str = "xunit1") -> tuple:
     if family == "xunit2":
         with xml_path.open(encoding="utf-8") as f:
             pass  # schema.validate(f)
-    xmldoc = ElementTree.parse(str(xml_path))
+    xmldoc = ET.parse(str(xml_path))
     return result, xmldoc.getroot()
-
-
-def test_single_evidence(pytester: Pytester):
-    pytester.makepyfile("""
-    import pytest
-    from pytest_junit_xray_xml import record_test_evidence
-
-
-    def test_record_pass(record_test_evidence):
-        evidences = {
-            "file1.txt": "My file content is text".encode("UTF-8")
-        }
-        record_test_evidence(evidences)
-        assert True
-
-    """)
-    _, root_node = run_and_parse(pytester, None)
-    actual_evidence = root_node.find(
-        "./testcase/properties"
-        "/property[@name='testrun_evidence']/item[@name='file1.txt']"
-    )
-    assert actual_evidence.text == "TXkgZmlsZSBjb250ZW50IGlzIHRleHQ="
 
 
 def test_single_description(pytester: Pytester):
@@ -158,4 +137,51 @@ def test_pass(pytester: Pytester):
     node = root_node.find(
         "./testcase[@name='test_pass']"
     )
-    assert len(node) == 0, ElementTree.tostring(node)
+    assert len(node) == 0, ET.tostring(node)
+
+
+def test_record_test_evidence_text(pytester: Pytester):
+    encoding = "UTF-8"
+    file_content = "My file content is text"
+    pytester.makepyfile(f"""
+    from pytest_junit_xray_xml import record_test_evidence
+
+    def test_record_test_evidence(record_test_evidence):
+        with record_test_evidence("file1.txt", "w", encoding="{encoding}") as f:
+            f.write("{file_content}")
+        assert True
+    """)
+    _, root_node = run_and_parse(pytester, None)
+    actual_evidence = root_node.find(
+        "./testcase/properties"
+        "/property[@name='testrun_evidence']/item[@name='file1.txt']"
+    ).text
+    expected_evidence = base64.b64encode(file_content.encode(encoding)).decode("us-ascii")
+    assert actual_evidence == expected_evidence
+
+
+def test_record_test_evidence_xml(pytester: Pytester):
+    pytester.makepyfile("""
+    from xml.etree.ElementTree import ElementTree, Element, canonicalize
+    from pytest_junit_xray_xml import record_test_evidence
+
+    def test_record_test_evidence(record_test_evidence):
+        xml_content = ElementTree(Element("my_root", my_attribute="1"))
+        with record_test_evidence("file1.xml", "wb") as f:
+            xml_content.write(f)
+
+        assert True
+    """)
+    _, root_node = run_and_parse(pytester, None)
+    test_evidence = (
+        root_node.find(
+            "./testcase/properties"
+            "/property[@name='testrun_evidence']/item[@name='file1.xml']"
+        )
+        .text
+        .encode("us-ascii")
+    )
+    actual_evidence = ET.canonicalize(base64.b64decode(test_evidence))
+    xml_content = ET.Element("my_root", my_attribute="1")
+    expected_evidence = ET.canonicalize(ET.tostring(xml_content))
+    assert actual_evidence == expected_evidence

--- a/tests/test_junit_xray_xml.py
+++ b/tests/test_junit_xray_xml.py
@@ -44,7 +44,7 @@ def test_single_description(pytester: Pytester):
     from pytest_junit_xray_xml import record_test_description
 
 
-    def test_record_pass(record_test_description):
+    def test_record_single_description(record_test_description):
         record_test_description("{expected_description}")
         assert True
 
@@ -63,7 +63,7 @@ def test_multiple_descriptions(pytester: Pytester):
     from pytest_junit_xray_xml import record_test_description
 
 
-    def test_record_pass(record_test_description):
+    def test_record_multiple_descriptions(record_test_description):
         record_test_description("This is my test description line 1")
         record_test_description("and line 2.")
         assert True
@@ -116,7 +116,7 @@ def test_single_key(pytester: Pytester):
     pytester.makepyfile(f"""
     from pytest_junit_xray_xml import record_test_key
 
-    def test_record_pass(record_test_key):
+    def test_record_test_key(record_test_key):
         record_test_key("{expected_key}")
         assert True
 


### PR DESCRIPTION
- added documentation
- `record_test_evidence` now works as a decorator